### PR TITLE
Fix 'run with sudo' check to check euid as well as sudo environment variable

### DIFF
--- a/ibeacon
+++ b/ibeacon
@@ -72,7 +72,7 @@ def process_command(c):
 
 # check to see if we are the superuser - returns 1 if yes, 0 if no
 def check_for_sudo():
-  if 'SUDO_UID' in os.environ.keys():
+  if 'SUDO_UID' in os.environ.keys() or os.geteuid() == 0:
     return 1
   else:
     print "Error: this script requires superuser privileges.  Please re-run with `sudo.'"


### PR DESCRIPTION
At present, the `check_for_sudo` function checks for the presence of an environment
variable to see if the command was run with sudo, and therefore has the correct
permissions to interact with the bluetooth device. This does not work in cases
where the script is invoked directly, for example from a systemd unit or init script

This patch extends `check_for_sudo` to examine the effective uid to see if it is '0'
(root) if the environment variable is not found
